### PR TITLE
Remove all emoji glyphs from the UI

### DIFF
--- a/src/HDRGammaController/ArgyllDownloadDialog.xaml
+++ b/src/HDRGammaController/ArgyllDownloadDialog.xaml
@@ -57,7 +57,6 @@
             <Border Grid.Row="0" Background="#252525" CornerRadius="8,8,0,0" MouseLeftButtonDown="TitleBar_MouseDown">
                 <Grid Margin="16,0">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                        <TextBlock Text="📦" FontSize="14" Margin="0,0,8,0"/>
                         <TextBlock Text="Download ArgyllCMS" FontWeight="Medium" FontSize="14"/>
                     </StackPanel>
                 </Grid>

--- a/src/HDRGammaController/CalibrationWindow.xaml
+++ b/src/HDRGammaController/CalibrationWindow.xaml
@@ -357,7 +357,7 @@
                                 <ColumnDefinition Width="Auto"/>
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
-                            <TextBlock Text="⚠" FontSize="18" Foreground="{StaticResource WarningBrush}"
+                            <TextBlock Text="!" FontSize="18" FontWeight="Bold" Foreground="{StaticResource WarningBrush}"
                                        VerticalAlignment="Top" Margin="0,0,10,0"/>
                             <TextBlock Grid.Column="1" TextWrapping="Wrap" Foreground="#FFD699">
                                 <Run FontWeight="SemiBold">Windowed mode may reduce measurement accuracy.</Run>
@@ -525,7 +525,7 @@
             <Border x:Name="WindowedModeBanner" Background="{StaticResource WarningBackgroundBrush}"
                     VerticalAlignment="Top" Padding="8,6" Visibility="Collapsed" Panel.ZIndex="100">
                 <TextBlock HorizontalAlignment="Center" Foreground="#FFD699" FontSize="12">
-                    <Run FontWeight="SemiBold">⚠ Windowed Mode</Run>
+                    <Run FontWeight="SemiBold">Windowed Mode</Run>
                     <Run> - Reduced accuracy. Full-screen recommended.</Run>
                 </TextBlock>
             </Border>
@@ -600,11 +600,11 @@
 
                         <!-- Control Buttons -->
                         <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Center">
-                            <Button x:Name="PauseButton" Content="⏸ Pause" Style="{StaticResource SubtleButton}"
+                            <Button x:Name="PauseButton" Content="Pause" Style="{StaticResource SubtleButton}"
                                     Click="Pause_Click" Margin="0,0,8,0"/>
-                            <Button x:Name="CancelMeasurementButton" Content="✕ Cancel" Style="{StaticResource SubtleButton}"
+                            <Button x:Name="CancelMeasurementButton" Content="Cancel" Style="{StaticResource SubtleButton}"
                                     Click="CancelMeasurement_Click" Margin="0,0,8,0"/>
-                            <Button x:Name="MuteButton" Content="🔊 Sound on" Style="{StaticResource SubtleButton}"
+                            <Button x:Name="MuteButton" Content="Sound: On" Style="{StaticResource SubtleButton}"
                                     Click="Mute_Click" ToolTip="Mute or unmute capture and completion sounds"/>
                         </StackPanel>
                     </Grid>
@@ -614,14 +614,13 @@
             <!-- Pause Overlay -->
             <Grid x:Name="PauseOverlay" Background="#CC1A1A1A" Visibility="Collapsed">
                 <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-                    <TextBlock Text="⏸" FontSize="48" HorizontalAlignment="Center" Margin="0,0,0,16"/>
                     <TextBlock Text="Calibration Paused" FontSize="24" FontWeight="SemiBold" HorizontalAlignment="Center"/>
                     <TextBlock x:Name="ResumeCountdownText" Text="Click Resume to continue"
                                Foreground="{StaticResource TextDim}" HorizontalAlignment="Center" Margin="0,8,0,24"/>
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                        <Button x:Name="ResumeButton" Content="▶ Resume" Style="{StaticResource ModernButton}"
+                        <Button x:Name="ResumeButton" Content="Resume" Style="{StaticResource ModernButton}"
                                 Click="Resume_Click" Margin="0,0,8,0"/>
-                        <Button Content="✕ Cancel" Style="{StaticResource SubtleButton}"
+                        <Button Content="Cancel" Style="{StaticResource SubtleButton}"
                                 Click="CancelMeasurement_Click"/>
                     </StackPanel>
                 </StackPanel>

--- a/src/HDRGammaController/CalibrationWindow.xaml.cs
+++ b/src/HDRGammaController/CalibrationWindow.xaml.cs
@@ -954,12 +954,12 @@ namespace HDRGammaController
                 {
                     case CalibrationState.Paused:
                         PauseOverlay.Visibility = Visibility.Visible;
-                        PauseButton.Content = "⏸ Paused";
+                        PauseButton.Content = "Paused";
                         PauseButton.IsEnabled = false;
                         break;
                     case CalibrationState.Running:
                         PauseOverlay.Visibility = Visibility.Collapsed;
-                        PauseButton.Content = "⏸ Pause";
+                        PauseButton.Content = "Pause";
                         PauseButton.IsEnabled = true;
                         break;
                 }
@@ -1021,14 +1021,14 @@ namespace HDRGammaController
         }
 
         private void UpdateMuteButton() =>
-            MuteButton.Content = CalibrationSounds.Muted ? "🔇 Muted" : "🔊 Sound on";
+            MuteButton.Content = CalibrationSounds.Muted ? "Sound: Muted" : "Sound: On";
 
         private void Pause_Click(object sender, RoutedEventArgs e)
         {
             _isPaused = true;
             _orchestrator?.Pause();
             PauseOverlay.Visibility = Visibility.Visible;
-            PauseButton.Content = "⏸ Paused";
+            PauseButton.Content = "Paused";
             PauseButton.IsEnabled = false;
         }
 
@@ -1044,7 +1044,7 @@ namespace HDRGammaController
             _isPaused = false;
             _orchestrator?.Resume();
             PauseOverlay.Visibility = Visibility.Collapsed;
-            PauseButton.Content = "⏸ Pause";
+            PauseButton.Content = "Pause";
             PauseButton.IsEnabled = true;
             ResumeCountdownText.Text = "Click Resume to continue";
         }

--- a/src/HDRGammaController/DashboardWindow.xaml
+++ b/src/HDRGammaController/DashboardWindow.xaml
@@ -303,7 +303,7 @@
                         <Button Content="Refresh" Margin="16,0,0,0" Click="Refresh_Click" Padding="8,4" Background="#444"/>
                     </StackPanel>
                     
-                    <ToggleButton x:Name="NightModeToggle" Grid.Column="2" Content="🌙 Night Mode" 
+                    <ToggleButton x:Name="NightModeToggle" Grid.Column="2" Content="Night Mode" 
                                   Width="320" Height="36" Padding="20,0" HorizontalAlignment="Right"
                                   IsChecked="{Binding IsNightModeEnabled, Mode=OneWay}"
                                   Click="NightModeToggle_Click" MouseRightButtonUp="NightModeToggle_RightClick">

--- a/src/HDRGammaController/DriverInstallDialog.xaml
+++ b/src/HDRGammaController/DriverInstallDialog.xaml
@@ -58,7 +58,6 @@
             <Border Grid.Row="0" Background="#252525" CornerRadius="8,8,0,0" MouseLeftButtonDown="TitleBar_MouseDown">
                 <Grid Margin="16,0">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                        <TextBlock Text="🔌" FontSize="14" Margin="0,0,8,0"/>
                         <TextBlock Text="USB Driver Required" FontWeight="Medium" FontSize="14"/>
                     </StackPanel>
                 </Grid>
@@ -96,7 +95,7 @@
                     <Border Background="#3D2D1D" BorderBrush="{StaticResource WarningBrush}" BorderThickness="1"
                             CornerRadius="4" Padding="10">
                         <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="⚠" Foreground="{StaticResource WarningBrush}" FontSize="16" Margin="0,0,8,0"/>
+                            <TextBlock Text="!" FontWeight="Bold" Foreground="{StaticResource WarningBrush}" FontSize="16" Margin="0,0,8,0"/>
                             <TextBlock Text="Note: X-Rite's own software (i1Profiler) may stop working after this. You can uninstall the ArgyllCMS driver later to restore it."
                                        TextWrapping="Wrap" Foreground="{StaticResource WarningBrush}" FontSize="11"/>
                         </StackPanel>
@@ -105,7 +104,6 @@
 
                 <!-- Installing state -->
                 <StackPanel x:Name="InstallingPanel" Visibility="Collapsed" VerticalAlignment="Center" HorizontalAlignment="Center">
-                    <TextBlock Text="⏳" FontSize="48" HorizontalAlignment="Center" Margin="0,0,0,16"/>
                     <TextBlock Text="Waiting for driver installer..." FontWeight="Medium" FontSize="16" HorizontalAlignment="Center"/>
                     <TextBlock Text="Complete the installation in the ArgyllCMS window"
                                Foreground="{StaticResource TextDim}" FontSize="12" HorizontalAlignment="Center" Margin="0,8,0,0"/>

--- a/src/HDRGammaController/ViewModels/MonitorViewModel.cs
+++ b/src/HDRGammaController/ViewModels/MonitorViewModel.cs
@@ -66,7 +66,7 @@ namespace HDRGammaController.ViewModels
                 
                 // Add settings option
                 SubItems.Add(new ActionViewModel("───────────", null));
-                SubItems.Add(new ActionViewModel("⚙ Settings...", new RelayCommand(_ => OpenSettings())));
+                SubItems.Add(new ActionViewModel("Settings...", new RelayCommand(_ => OpenSettings())));
             }
             else
             {
@@ -75,7 +75,7 @@ namespace HDRGammaController.ViewModels
                  
                 // Add settings option
                 SubItems.Add(new ActionViewModel("───────────", null));
-                SubItems.Add(new ActionViewModel("⚙ Settings...", new RelayCommand(_ => OpenSettings())));
+                SubItems.Add(new ActionViewModel("Settings...", new RelayCommand(_ => OpenSettings())));
             }
         }
         

--- a/src/HDRGammaController/WhiteTrimWindow.cs
+++ b/src/HDRGammaController/WhiteTrimWindow.cs
@@ -60,8 +60,8 @@ namespace HDRGammaController
             }
 
             var nudges = new StackPanel { Orientation = Orientation.Horizontal, HorizontalAlignment = HorizontalAlignment.Center };
-            nudges.Children.Add(Make("◀ Green", 0, +Step));
-            nudges.Children.Add(Make("Magenta ▶", 0, -Step));
+            nudges.Children.Add(Make("< Green", 0, +Step));
+            nudges.Children.Add(Make("Magenta >", 0, -Step));
             nudges.Children.Add(new Border { Width = 16 });
             nudges.Children.Add(Make("Warmer", +Step, +Step * 0.35));
             nudges.Children.Add(Make("Cooler", -Step, -Step * 0.35));
@@ -97,7 +97,7 @@ namespace HDRGammaController
             var hint = new TextBlock
             {
                 Text = "Compare this gray against your reference display, then nudge until they match. " +
-                       "Each step rebuilds the profile live (~1 second). Arrows: ←→ green/magenta, ↑↓ cooler/warmer.",
+                       "Each step rebuilds the profile live (~1 second). Arrow keys: Left/Right green/magenta, Up/Down cooler/warmer.",
                 FontSize = 12,
                 Foreground = Brushes.Black,
                 Opacity = 0.65,


### PR DESCRIPTION
Follow-up to #3: strips every emoji/pictograph from user-facing UI (pause/resume/cancel/mute buttons, overlays, warning banners, dialog title icons, night mode toggle, tray settings entries, white-trim nudges). Functional monochrome marks (menu checkmarks, close X, result check/cross) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)